### PR TITLE
Add BufferedImage Converters

### DIFF
--- a/Java/src/pottslab/PLImage.java
+++ b/Java/src/pottslab/PLImage.java
@@ -133,12 +133,23 @@ public class PLImage {
 
 	public BufferedImage toBufferedImage() {
 		final BufferedImage img = new BufferedImage(mRow, mCol, BufferedImage.TYPE_INT_RGB);
+		if(mLen == 1) {
 			for (int i = 0; i < mRow; i++) {
 				for (int j = 0; j < mCol; j++) {
 					float c = (float) Math.min(Math.abs(mData[i][j].get(0)), 1.0);
 					img.setRGB(i, j, new Color(c, c, c).getRGB());
 				}
 			}
+		} else {
+			for (int i = 0; i < mRow; i++) {
+				for (int j = 0; j < mCol; j++) {
+					float r = (float) Math.min(Math.abs(mData[i][j].get(0)), 1.0);
+					float g = (float) Math.min(Math.abs(mData[i][j].get(1)), 1.0);
+					float b = (float) Math.min(Math.abs(mData[i][j].get(2)), 1.0);
+					img.setRGB(i, j, new Color(r, g, b).getRGB());
+				}
+			}
+		}
 		return img;
 	}
 

--- a/Java/src/pottslab/PLImage.java
+++ b/Java/src/pottslab/PLImage.java
@@ -153,4 +153,18 @@ public class PLImage {
 		return img;
 	}
 
+	public static PLImage fromBufferedImage(BufferedImage image) {
+		double[][][] imgdata = new double[image.getWidth()][image.getHeight()][3];
+		float[] tmp = new float[3];
+		for(int i = 0; i < image.getWidth(); i++) {
+			for(int j = 0; j < image.getHeight(); j++) {
+				Color c = new Color(image.getRGB(i,j));
+				c.getRGBColorComponents(tmp);
+				for (int k = 0; k < 3; k++) {
+					imgdata[i][j][k] = tmp[k];
+				}
+			}
+		}
+		return new PLImage(imgdata);
+	}
 }

--- a/Java/src/pottslab/PLImage.java
+++ b/Java/src/pottslab/PLImage.java
@@ -108,15 +108,7 @@ public class PLImage {
 
 
     public void show() {
-	final BufferedImage img = new BufferedImage(mRow, mCol, BufferedImage.TYPE_INT_RGB);
-	Graphics2D g = (Graphics2D)img.getGraphics();
-	for(int i = 0; i < mRow; i++) {
-	    for(int j = 0; j < mCol; j++) {
-		float c = (float) Math.min(Math.abs(mData[i][j].get(0)), 1.0);
-		g.setColor(new Color(c, c, c));
-		g.fillRect(i, j, 1, 1);
-	    }
-	}
+		final BufferedImage img = toBufferedImage();
 
 	JFrame frame = new JFrame("Image test");
 	//frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -138,5 +130,16 @@ public class PLImage {
 	frame.pack();
 	frame.setVisible(true);
     }
+
+	public BufferedImage toBufferedImage() {
+		final BufferedImage img = new BufferedImage(mRow, mCol, BufferedImage.TYPE_INT_RGB);
+			for (int i = 0; i < mRow; i++) {
+				for (int j = 0; j < mCol; j++) {
+					float c = (float) Math.min(Math.abs(mData[i][j].get(0)), 1.0);
+					img.setRGB(i, j, new Color(c, c, c).getRGB());
+				}
+			}
+		return img;
+	}
 
 }


### PR DESCRIPTION
Add converter functions between PLImage and BufferedImage. This allows easy use in Java with

```
PLImage img = PLImage.fromBufferedImage(ImageIO.read(new File("input.png")));
[...]
ImageIO.write(img.toBufferedImage(), "png", new File("output.png"));
```