### PR TITLE
Auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -106,9 +106,13 @@ jobs:
       name: pypi
       url: https://pypi.org/project/pottslab/
     permissions:
-      id-token: write   # required for OIDC trusted publishing
+      id-token: write    # required for OIDC trusted publishing
+      contents: write    # required for the GitHub Release step below
 
     steps:
+      - name: Checkout (for CHANGELOG.md)
+        uses: actions/checkout@v4
+
       - name: Download all wheel and sdist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -124,3 +128,28 @@ jobs:
         # Repository:   Pottslab
         # Workflow:     build_wheels.yml
         # Environment:  pypi
+
+      - name: Extract release notes from CHANGELOG.md
+        # Pulls the section bounded by `## <ver>` (bracket-tolerant) and
+        # the next `## ` heading. Falls back to a tag-commits link if
+        # the heading is missing or CHANGELOG.md doesn't exist.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          if [ -f CHANGELOG.md ]; then
+            awk -v ver="$VER" '
+              $0 ~ "^## \\[?" ver "\\]?( |$)" { found=1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md > release-notes.md
+          fi
+          [ -s release-notes.md ] || echo "See [tag commits](https://github.com/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME})." > release-notes.md
+
+      - name: Create GitHub Release
+        # Idempotent: updates an existing Release for this tag instead
+        # of erroring, so manual pre-creation never blocks a re-run.
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
## Summary

Pushing a `v*` tag publishes to PyPI but does **not** create an entry on the GitHub Releases page. This PR closes that gap: the publish job now also creates a GitHub Release, with the matching `## <version>` section of `CHANGELOG.md` as the body and all wheels + sdist attached as assets.

Identical pattern to:
- mstorath/CircleMedianFilter#6
- (parallel PRs in CSSD, L1TV, DCEBE)

## How it works

In the existing `publish` job, after the PyPI upload:

1. `actions/checkout@v4` puts `CHANGELOG.md` on disk.
2. An awk one-liner extracts the `## <ver>` section verbatim — bracket-tolerant so it accepts both `## [1.0.0] - date` and `## 1.0.0 — date`. Falls back to a tag-commits link if nothing matches.
3. `softprops/action-gh-release@v2` creates the Release with that as the body, attaches `dist/*`, and stacks `generate_release_notes: true` on top for an auto-generated PR/commit summary.

`contents: write` added to the publish job's permissions (required by the release action). `id-token: write` for OIDC stays as-is.

Idempotent: updates in place if a Release for the tag already exists.

## Test plan

- [ ] Awk extraction tested against current `CHANGELOG.md` locally — the `## 1.0.0` heading matches.
- [ ] First real exercise: next `v*` tag push.
- [ ] No effect on the build/sdist/publish-to-PyPI jobs themselves.