### PR TITLE
Add post-publish verify step (real install + import + call)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -153,3 +153,22 @@ jobs:
           body_path: release-notes.md
           generate_release_notes: true
           files: dist/*
+
+      - name: Verify uploaded package (real install + import + call)
+        # Defends against a class of silent failures where PyPI accepted
+        # the upload but the package isn't actually usable (renamed module,
+        # missing __init__, broken native binding, ABI mismatch, etc.).
+        # CMF v0.1.7 added this after the previous verify step had been
+        # silently passing for years against an unrelated placeholder
+        # package — see devcontainer reports/11-cmf-v0.1.7-release.md.
+        run: |
+          # Brief delay so PyPI's CDN settles the new version.
+          sleep 30
+          pip install --no-cache-dir --index-url https://pypi.org/simple/ pottslab
+          python -c "
+          import numpy as np, pottslab
+          from importlib.metadata import version
+          out = pottslab.min_l2_potts(np.zeros(8), gamma=0.1)
+          assert out.shape == (8,), f'unexpected shape {out.shape}'
+          print(f'pottslab {version(\"pottslab\")} verify OK')
+          "


### PR DESCRIPTION
## Summary

Adds a post-publish smoke check to the publish job: after `gh-action-pypi-publish` finishes, the workflow does a real `pip install pottslab` from `pypi.org/simple/`, imports the module, and runs a tiny `min_l2_potts` call to exercise the binding.

PyPI accepting the upload is not the same as \`pip install\` working. The check catches:
- A renamed module / wrong package name in the workflow (the bug that was silent on CMF for years against the unrelated placeholder \`your-package-name\`)
- Broken `__init__.py`
- ABI / manylinux mismatch
- Missing or broken native binding

This mirrors the step that landed in `CircleMedianFilter` during v0.1.7. Same backport landing in parallel for CSSD, L1TV, DCEBE.

## Test plan

- [ ] First real exercise: next `v*` tag push.
- [ ] Idempotent: only runs after a successful PyPI upload, so a publish failure (which would make the verify install fail anyway) doesn't cascade.