### PR TITLE
Update Andreas Weinmann's email to @thws.de

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     affiliation: "Lab for Mathematical Methods in Computer Vision and Machine Learning, Technische Hochschule Würzburg-Schweinfurt"
   - family-names: Weinmann
     given-names: Andreas
-    email: andreas.weinmann@h-da.de
+    email: andreas.weinmann@thws.de
     orcid: "https://orcid.org/0000-0002-4969-7609"
     affiliation: "Department of Mathematics and Natural Sciences, Hochschule Darmstadt"
 preferred-citation:


### PR DESCRIPTION
Single-line CITATION.cff change. Aligns with the canonical email for A. Weinmann (per CLAUDE.md author defaults across the lab repo family). CSSD, L1TV, and CircleMedianFilter already have this; Pottslab and MumfordShah2D were the two outliers. The stale local `claude/weinmann-email-2026-05` branch contained unrelated reverts and was unmergeable; this PR replaces it with a minimal change.