### PR TITLE
Bump to v1.0.1 (metadata maintenance release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.1 — 2026-05-11
+
+Metadata maintenance release. No algorithmic changes.
+
+- README harmonised across the lab repo family: badge block, restructured Quickstart (Python first, MATLAB second, standalone third), standardised "See also" section linking the five sibling repos and two external related projects.
+- AI-port narrative moved from the README's lead to a discreet "Project history" footer.
+- Duplicate `License.txt` deleted (was identical to `LICENSE`).
+- `CITATION.cff` populated with `version` and `date-released` fields so citation tooling reads from the file directly rather than falling back to GitHub Releases.
+- Andreas Weinmann's email updated to `andreas.weinmann@thws.de` in `CITATION.cff`.
+- Post-publish verify step added to the release workflow (installs the published wheel and runs an import + call smoke test).
+- Auto-create GitHub Release on tag push (alongside PyPI publish).
+
 ## 1.0.0 — 2026-05-05
 
 First stable release of the Python/Rust port.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite both the software and the associated paper below."
 title: "Pottslab: Multilabel image segmentation based on the Potts model"
-version: 1.0.0
-date-released: 2026-05-07
+version: 1.0.1
+date-released: 2026-05-11
 abstract: "Unsupervised multilabel image segmentation (color, gray, and multichannel) based on the Potts model — also known as the piecewise-constant Mumford-Shah model. Provides MATLAB / Java implementations and a Python package backed by a Rust core."
 type: software
 url: "https://github.com/mstorath/Pottslab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_pottslab_core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Rust core for pottslab Python package — ported from Java by Claude Sonnet coding agent (Anthropic, 2026)"
 authors = [

--- a/pottslab/__init__.py
+++ b/pottslab/__init__.py
@@ -55,7 +55,7 @@ References
    Potts functionals." IEEE Transactions on Signal Processing, 2014.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __original_authors__ = "Martin Storath, Andreas Weinmann"
 __ported_by__ = (
     "Claude Sonnet coding agent (Anthropic, 2026) — "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pottslab"
-version = "1.0.0"
+version = "1.0.1"
 description = "Potts model signal/image processing — Python/Rust port of MATLAB/Java pottslab (Storath & Weinmann)"
 readme = "README_PYTHON.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Phase 3 maintenance release for Pottslab. No algorithmic changes.

Aligns all release-version surfaces in one commit per the new CLAUDE.md release-management rule:

- `pyproject.toml::version` → `1.0.1`
- `Cargo.toml::version` → `1.0.1`
- `pottslab/__init__.py::__version__` → `"1.0.1"`
- `CITATION.cff` → `version: 1.0.1`, `date-released: 2026-05-11`
- `CHANGELOG.md` → new `## 1.0.1 — 2026-05-11` entry summarising drift since v1.0.0

## What landed in this version

- README harmonised across the lab repo family (Pass F).
- Duplicate `License.txt` deleted (was identical to `LICENSE`).
- Andreas Weinmann's email updated to `andreas.weinmann@thws.de`.
- Post-publish verify step added to release workflow.
- Auto-create GitHub Release on tag push wired up.
- `CITATION.cff` version/date-released fields populated (Pass A).

## After merge

Tag `v1.0.1` on the merge commit and push the tag. The auto-release workflow handles PyPI publish + GitHub Release creation.

## Test plan
- [ ] Release workflow runs to completion on tag push
- [ ] PyPI shows `1.0.1` with the harmonised README rendering correctly
- [ ] GitHub Release object created with CHANGELOG entry as the body