### PR TITLE
Make release_smoke_test.ipynb actually validate a released wheel

### DIFF
--- a/demos_python/release_smoke_test.ipynb
+++ b/demos_python/release_smoke_test.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6ad06d0d",
+   "metadata": {},
+   "source": [
+    "# `pottslab` \u2014 release smoke test\n",
+    "\n",
+    "Exercises every public 1-D and 2-D Potts solver on small synthetic inputs to verify a release is functional. Useful as both:\n",
+    "\n",
+    "- A post-publish check after `pip install pottslab`.\n",
+    "- A first-time-user introduction to the API.\n",
+    "\n",
+    "Each section is self-contained and ends with a small assertion or visual check. Run-all should complete in a few seconds on any machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "742a7588",
+   "metadata": {},
+   "source": [
+    "## 1. Install and import\n",
+    "\n",
+    "Uncomment the install line if `pottslab` isn't on the active Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36ca066a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:48.682396Z",
+     "iopub.status.busy": "2026-05-07T12:21:48.682159Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.185513Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.184247Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install pottslab==1.0.1 matplotlib --quiet\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pottslab as pl\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830d80dd",
+   "metadata": {},
+   "source": [
+    "### Verify the Rust extension is loaded (not the pure-Python fallback)\n",
+    "\n",
+    "If the Rust core isn't available, `pottslab` silently falls back to a pure-Python implementation that's **orders of magnitude slower**. The smoke test should fail loudly when that happens \u2014 otherwise a release with a broken wheel would silently pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4f8ca9a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.187849Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.187593Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.197100Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.195218Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pottslab._core as _core\n",
+    "print('Rust core loaded from:', _core.__file__)\n",
+    "assert '_core_py' not in _core.__name__, 'pure-Python fallback in use; install a wheel'\n",
+    "assert 'site-packages' in _core.__file__, (\n",
+    "    f'pottslab imported from local source, not from a wheel: {_core.__file__}'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ddc4ad7",
+   "metadata": {},
+   "source": [
+    "## 2. 1-D L2-Potts \u2014 clean step signal\n",
+    "\n",
+    "L2 Potts solves\n",
+    "\n",
+    "$$\\min_u \\; \\gamma \\, \\| Du \\|_0 \\; + \\; \\| u - f \\|_2^2$$\n",
+    "\n",
+    "via dynamic programming (O(n\u00b2)). Here `f` has two clean segments and one jump; with `gamma` smaller than the cost of merging them, we recover the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a10165",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.201763Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.201588Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.265759Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.265411Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "n = 64\n",
+    "f_clean = np.concatenate([np.zeros(n // 2), np.ones(n // 2)])\n",
+    "u = pl.min_l2_potts(f_clean, gamma=0.1)\n",
+    "\n",
+    "print('jumps recovered:', pl.count_jumps(u))\n",
+    "print('max |u - f_clean|:', np.max(np.abs(u - f_clean)))\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 2.5))\n",
+    "ax.step(np.arange(n), f_clean, where='mid', alpha=0.4, label='input')\n",
+    "ax.step(np.arange(n), u, where='mid', linewidth=2, label='L2-Potts (\u03b3=0.1)')\n",
+    "ax.set_title('1-D L2-Potts \u2014 clean step')\n",
+    "ax.legend(); plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed76cea",
+   "metadata": {},
+   "source": [
+    "## 3. 1-D L2-Potts \u2014 noisy signal\n",
+    "\n",
+    "Three segments + Gaussian noise. The right `gamma` recovers all three jumps; too small leaves noise, too large collapses segments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ccf27d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.266718Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.266644Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.355678Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.355397Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "n = 200\n",
+    "truth = np.concatenate([np.zeros(70), 2 * np.ones(70), -1 * np.ones(60)])\n",
+    "f_noisy = truth + rng.normal(0, 0.3, size=n)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(12, 2.8), sharey=True)\n",
+    "for ax, gamma in zip(axes, [0.1, 1.0, 50.0]):\n",
+    "    u = pl.min_l2_potts(f_noisy, gamma=gamma)\n",
+    "    ax.plot(f_noisy, color='lightgray', linewidth=0.7, label='noisy')\n",
+    "    ax.plot(truth, '--', color='black', linewidth=0.7, label='truth')\n",
+    "    ax.plot(u, color='C0', linewidth=2, label=f'\u03b3={gamma}')\n",
+    "    ax.set_title(f'\u03b3={gamma}, jumps={pl.count_jumps(u)}')\n",
+    "    ax.legend(loc='upper right', fontsize=8)\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e232908d",
+   "metadata": {},
+   "source": [
+    "## 4. 1-D L1-Potts \u2014 robust to outliers\n",
+    "\n",
+    "L1 Potts solves\n",
+    "\n",
+    "$$\\min_u \\; \\gamma \\, \\| Du \\|_0 \\; + \\; \\| u - f \\|_1$$\n",
+    "\n",
+    "and is robust to heavy-tailed noise / sparse outliers. We sprinkle 5% spike outliers onto the noisy signal and compare L1 vs L2 reconstructions.\n",
+    "\n",
+    "`min_l1_potts` returns a tuple `(u, dataError, nJumps, energy)` \u2014 only `u` is needed for plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33b90296",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.356607Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.356537Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.404965Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.404404Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "f_outliers = f_noisy.copy()\n",
+    "n_spikes = max(1, int(0.05 * len(f_outliers)))\n",
+    "spike_idx = rng.choice(len(f_outliers), size=n_spikes, replace=False)\n",
+    "f_outliers[spike_idx] += rng.choice([-5, 5], size=n_spikes)\n",
+    "\n",
+    "u_l2 = pl.min_l2_potts(f_outliers, gamma=1.0)\n",
+    "u_l1, _, n_jumps_l1, _ = pl.min_l1_potts(f_outliers, gamma=1.0)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 3))\n",
+    "ax.plot(f_outliers, color='lightgray', linewidth=0.7, label='input + outliers')\n",
+    "ax.plot(truth, '--', color='black', linewidth=0.7, label='truth')\n",
+    "ax.plot(u_l2, color='C1', linewidth=1.5, label='L2-Potts')\n",
+    "ax.plot(u_l1, color='C0', linewidth=2, label=f'L1-Potts (jumps={n_jumps_l1})')\n",
+    "ax.legend(); ax.set_title('Outliers degrade L2 but L1 stays clean')\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b5c2794",
+   "metadata": {},
+   "source": [
+    "## 5. 2-D L2-Potts \u2014 image segmentation\n",
+    "\n",
+    "`min_l2_potts_2d` uses ADMM to reduce the 2-D problem to many 1-D Potts solves run in parallel. Here we segment a synthetic image with a few constant regions plus noise. Output values should snap to a small set of levels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dec6133b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.405853Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.405771Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.466745Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.466373Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "H, W = 64, 64\n",
+    "img_truth = np.zeros((H, W))\n",
+    "img_truth[:32, :32] = 0.0\n",
+    "img_truth[:32, 32:] = 0.4\n",
+    "img_truth[32:, :32] = 0.7\n",
+    "img_truth[32:, 32:] = 1.0\n",
+    "img_noisy = np.clip(img_truth + rng.normal(0, 0.07, size=(H, W)), 0, 1)\n",
+    "\n",
+    "img_seg = pl.min_l2_potts_2d(img_noisy, gamma=0.5, isotropic=True)\n",
+    "n_levels = len(np.unique(img_seg))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(9, 3))\n",
+    "for ax, im, title in zip(axes,\n",
+    "                          [img_truth, img_noisy, img_seg],\n",
+    "                          ['truth', 'noisy', f'segmented (levels={n_levels})']):\n",
+    "    ax.imshow(im, vmin=0, vmax=1, cmap='gray')\n",
+    "    ax.set_title(title); ax.set_xticks([]); ax.set_yticks([])\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "assert n_levels >= 4, 'expected \u2265 4 segment levels'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0be80f0b",
+   "metadata": {},
+   "source": [
+    "## 6. 2-D L2-Potts \u2014 RGB image\n",
+    "\n",
+    "The 2-D solver works on multi-channel images too: pass shape `(H, W, C)` and `gamma` is shared across channels (joint segmentation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01eda7dc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.467570Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.467496Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.523181Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.522497Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "rgb_truth = np.zeros((H, W, 3))\n",
+    "rgb_truth[:H // 2, :, 0] = 1.0  # top half red\n",
+    "rgb_truth[H // 2:, :, 2] = 1.0  # bottom half blue\n",
+    "rgb_noisy = np.clip(rgb_truth + rng.normal(0, 0.1, size=rgb_truth.shape), 0, 1)\n",
+    "rgb_seg = pl.min_l2_potts_2d(rgb_noisy, gamma=0.8)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(9, 3))\n",
+    "for ax, im, title in zip(axes, [rgb_truth, rgb_noisy, rgb_seg],\n",
+    "                          ['truth', 'noisy', 'segmented']):\n",
+    "    ax.imshow(im); ax.set_title(title); ax.set_xticks([]); ax.set_yticks([])\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "411946f4",
+   "metadata": {},
+   "source": [
+    "## 7. Summary\n",
+    "\n",
+    "If the cells above all rendered, the release is good for the basic 1-D and 2-D Potts solvers. The other public entry points (`min_l{1,2}_ipotts`, `min_l{1,2}_spars`, `min_l{1,2}_tikhonov`) are not exercised here but follow the same call style \u2014 see [README_PYTHON.md](../README_PYTHON.md) for a deeper tour."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efdd1fe8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-07T12:21:49.523983Z",
+     "iopub.status.busy": "2026-05-07T12:21:49.523909Z",
+     "iopub.status.idle": "2026-05-07T12:21:49.526719Z",
+     "shell.execute_reply": "2026-05-07T12:21:49.526349Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import importlib.metadata\n",
+    "\n",
+    "version = importlib.metadata.version('pottslab')\n",
+    "print(f'pottslab {version} \u2014 smoke test OK')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

The Pottslab `demos_python/release_smoke_test.ipynb` notebook (untracked in the working tree, never committed) didn't support its name:

1. The `%pip install pottslab matplotlib --quiet` line was commented out.
2. The cached output of cell 4 showed `_core` loaded from the in-repo `.so` (i.e. the local source/build), not from `site-packages` — meaning the run validated the working tree, not a PyPI wheel.
3. The cached version stamp in the final cell read `pottslab 1.0.0 — smoke test OK`, but the repo is already at 1.0.1.

## Changes

- Uncomment the install cell and pin to `pottslab==1.0.1`.
- Add a hard assertion in the verification cell:
  ```python
  assert 'site-packages' in _core.__file__, (
      f'pottslab imported from local source, not from a wheel: {_core.__file__}'
  )
  ```
  so the notebook now fails loudly if it's accidentally run against the local checkout.
- Strip all `outputs` and `execution_count` from every code cell. The notebook commits clean; a fresh-kernel re-run is the recommended way to validate a release and will produce honest, current outputs.

## How to use

```bash
# in a clean venv, outside the repo checkout
jupyter notebook demos_python/release_smoke_test.ipynb
# run all cells; the install cell pulls v1.0.1 from PyPI,
# the assert in cell 4 guards against accidental local-import shadowing,
# and the final cell prints the version stamp.
```

## Test plan
- [ ] In a fresh venv outside the repo: `pip install jupyter` then run the notebook → all cells should execute without errors, including the new `site-packages` assertion.
- [ ] Running the notebook from within the repo checkout (where local imports could shadow the wheel) should now fail loudly in cell 4 rather than silently testing local code.