### PR TITLE
Drop hard version pin in release_smoke_test.ipynb

### DIFF
--- a/demos_python/release_smoke_test.ipynb
+++ b/demos_python/release_smoke_test.ipynb
@@ -39,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install pottslab==1.0.1 matplotlib --quiet\n",
+    "%pip install --upgrade pottslab matplotlib --quiet\n",
     "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
## Summary

Follow-up to #11. The release smoke test notebook installed `pottslab==1.0.1`, which would silently keep validating v1.0.1 after the next release ships. Replaced with `--upgrade pottslab` so the install cell always pulls the latest published wheel.

## Test plan
- [ ] Re-run the notebook in a fresh kernel — install line now fetches the current release rather than the pinned 1.0.1.